### PR TITLE
Rel 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Change Log
 
+## 3.5.0 (2024-02-27)
++ implement run-time configuration for address leds RGB color order option for WS2812, Closes #54
++ update windows batch installer
++ add font Awesome icons to UI buttons
++ reworked LOG macros, updated macro will allow to set severity level and component tag
+* DFPlayer adapter
+   - use forked DFMiniMp3 lib
+   - keep cfg in json file
+   - add effect track loop function
++ Button - reimplement button control
+   - use new ESPAsyncButton library for button handling
+   - implement event-based button<>lamp communication
+   - implement UI configuration for button, gpio, logic level, etc...
+   - implement UI configuration for button events, i.e. mapping actions to button events
+   - implement UI configuration for button timings 
+* Effects
+   - removed rudiment "individual brightness" from effect configs
+   - EffectFlags add control to randomly switch flags
+   - fix TetrisClock orientation
+   - исправлен эффект "Узоры" на широких экранах
+   - fix fireworks running on large screens. Closes #47
++ TM1637 rework
+   - tm's options are kept in a display.json file
+   - modified 1637 driver to handle appended messages
+   - TMDisplay class now handles events from a message bus
+     - show IP on WiFi connect
+     - show power On/Off
+     - show Brightness change
+     - tm display track brightness control from button events
++ Lamp class refactoring
+   - replace EFFSWITCH enum with enum class effswitch_t
+   - rename Lamp::effects member to Lamp::effwrkr
+   - remove long obsolete sync_parameters()
+   - rename overloaded Lamp::switcheffect to private Lamp::_switcheffect
++ add IPC to EmbUI.feeders event publisher
++ Implement ESP32 event loop bus for exchangind control messages between lamp's componets
+   - control matrix MOSFET via event bus
+   - power on/off events via event loop bus
+   - brightness control events
+   - effect switch events
+- remove obsolete code
+   - RTC module related libs and code
+   - DS temp sensor related
+   - E131 related code
+   - remove MP3PLAYER define
+   - remove obsolete ESP_USE_BUTTON define and related code
+   - убрана кнопка "калибровка микрофона"
+   - remove button actions from interfaces.cpp
+   - remove old tm methood calls from encoder and rtc
+   - alarm
+   - events
+   - gauge
+   - some webui related code
+   - code related to pending/current effect switching from EffectWorker
+- Other
+   - восстанавливать статус активности микрофона после перезагрузки. Closes #19
+   - removed build_time define MIC_EFFECTS
+
+
 ## 3.4.0 (2023-12-01)
 - Update EmbUI resources
 - Update Builder scripts

--- a/include/config.h
+++ b/include/config.h
@@ -138,10 +138,6 @@ JeeUI2 lib used under MIT License Copyright (c) 2019 Marsel Akhkamov
 
 
 
-#ifndef COLOR_ORDER
-#define COLOR_ORDER           (GRB)                         // порядок цветов на ленте. Если цвет отображается некорректно - меняйте. Начать можно с RGB
-#endif
-
 #ifndef OFF_BRIGHTNESS
 #define OFF_BRIGHTNESS          (2U)                        // яркость вывода текста в случае выключенной лампы
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ common =
     https://github.com/toblum/TetrisAnimation
 
 vortigont =
-    https://github.com/vortigont/EmbUI
+    https://github.com/vortigont/EmbUI#v3.1
     https://github.com/vortigont/LedFB
     https://github.com/vortigont/TM1637
     https://github.com/vortigont/ESPAsyncButton

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -786,7 +786,7 @@ void ui_block_mainpage_switches(Interface *interf, const JsonObject *data, const
     interf->checkbox(TCONST_drawbuff, myLamp.isDrawOn(), TINTF_0CE, true);
     interf->checkbox(TCONST_Mic, myLamp.isMicOnOff(), TINTF_012, true);
     interf->checkbox(TCONST_AUX, embui.paramVariant(TCONST_AUX), TCONST_AUX, true);
-    interf->checkbox(T_mp3mute, myLamp.isONMP3(), "MP3 Mute" /*TINTF_099*/, true);
+    interf->checkbox(T_mp3mute, myLamp.isMP3mute(), "MP3 Mute" /*TINTF_099*/, true);
 
 #ifdef LAMP_DEBUG
     interf->checkbox(TCONST_debug, myLamp.isDebugOn(), TINTF_08E, true);
@@ -1078,7 +1078,8 @@ void set_overlay_drawing(Interface *interf, const JsonObject *data, const char* 
 void set_mp3mute(Interface *interf, const JsonObject *data, const char* action){
     if (!data) return;
 
-    int v = (*data)[T_mp3mute];
+    bool v = (*data)[T_mp3mute];
+    myLamp.setMP3mute(v);
     EVT_POST(LAMP_SET_EVENTS, e2int(v ? evt::lamp_t::mp3mute : evt::lamp_t::mp3unmute ));
 }
 
@@ -1087,25 +1088,6 @@ void set_mp3volume(Interface *interf, const JsonObject *data, const char* action
     int volume = (*data)[T_mp3vol];
     embui.var(T_mp3vol, volume);
     EVT_POST_DATA(LAMP_SET_EVENTS, e2int(evt::lamp_t::mp3vol), &volume, sizeof(int));
-
-    //mp3->setVolume(volume);
-}
-
-void set_mp3_player(Interface *interf, const JsonObject *data, const char* action){
-    if (!data) return;
-/*
-    if(!myLamp.isONMP3()) return;
-    uint16_t cur_palyingnb = mp3->getCurPlayingNb();
-    if(data->containsKey(CMD_MP3_PREV)){
-        mp3->playEffect(cur_palyingnb-1,"");
-    } else if(data->containsKey(CMD_MP3_NEXT)){
-        mp3->playEffect(cur_palyingnb+1,"");
-    } else if(data->containsKey(TCONST_mp3_p5)){
-        mp3->playEffect(cur_palyingnb-5,"");
-    } else if(data->containsKey(TCONST_mp3_n5)){
-        mp3->playEffect(cur_palyingnb+5,"");
-    }
-*/
 }
 
 /*
@@ -1553,10 +1535,6 @@ void embui_actions_register(){
 #endif
 
 
-    embui.action.add(CMD_MP3_PREV, set_mp3_player);
-    embui.action.add(CMD_MP3_NEXT, set_mp3_player);
-    //embui.action.add(TCONST_mp3_p5, set_mp3_player);
-    //embui.action.add(TCONST_mp3_n5, set_mp3_player);
 /* #ifdef ENCODER
     embui.action.add(TCONST_set_enc, set_settings_enc);
 #endif

--- a/src/lamp.cpp
+++ b/src/lamp.cpp
@@ -192,24 +192,6 @@ void Lamp::power(bool flag) // флаг включения/выключения 
   save_flags();
 }
 
-/*
-temporary disable
-void Lamp::playEffect(bool isPlayName, EFFSWITCH action){
-  if( mp3!=nullptr && mp3->isOn() &&
-      effwrkr.getCurrent()>0 &&
-      (flags.playEffect ||
-        ((isLampOn() || millis()>5000) && flags.playMP3 && action!=EFFSWITCH::SW_NEXT_DEMO && action!=EFFSWITCH::SW_RND)
-      )
-    ){
-    LOG(printf_P, PSTR("playEffect soundfile:%s, effect:%d, delayed:%d\n"), effwrkr.getSoundfile().c_str(), effwrkr.getCurrent(), (flags.playName && !flags.playMP3));
-    if(!flags.playMP3 || (flags.playEffect && action!=EFFSWITCH::SW_NEXT_DEMO && action!=EFFSWITCH::SW_RND)) // для mp3-плеера есть отдельное управление
-      mp3->playEffect(effwrkr.getCurrent(), effwrkr.getSoundfile(), (isPlayName && mp3!=nullptr && mp3->isOn() && !flags.playMP3)); // влияние на отложенное воспроизведение, но не для MP3-плеера
-  } else {
-    mp3->setCurEffect(effwrkr.getCurrent());
-  }
-}
-*/
-
 void Lamp::startRGB(CRGB &val){
   rgbColor = val;
   storedMode = ((mode == LAMPMODE::MODE_RGBLAMP) ? storedMode: mode);
@@ -482,16 +464,6 @@ void Lamp::_switcheffect(effswitch_t action, bool fade, uint16_t effnb, bool ski
     effwrkr.switchEffect(effnb, true);
 
   bool isShowName = (mode==LAMPMODE::MODE_DEMO && flags.showName);
-  bool isPlayName = (isShowName && flags.playName && !flags.playMP3 && effwrkr.getCurrent()>0);
-
-  // show effects's name on screen and play name over speaker (if set)
-/*
-  if(isShowName){
-    if(isPlayName && mp3!=nullptr && mp3->isOn()) // воспроизведение 
-      mp3->playName(effwrkr.getCurrent());
-  }
-*/
-  playEffect(isPlayName, action); // воспроизведение звука, с проверкой текущего состояния
 
   setBrightness(globalBrightness);      // need to reapply brightness as effect's curve might have changed
 

--- a/src/lamp.h
+++ b/src/lamp.h
@@ -114,12 +114,12 @@ struct {
     bool showName:1;        // отображение имени в демо
     bool isMicOn:1;         // глобальное включение/выключение микрофона
     bool effHasMic:1;       // микрофон для эффекта
-    bool isOnMP3:1;         // включен ли плеер?
+    bool mp3mute:1;         // включен ли плеер?
     bool isBtn:1;           // включена ли кнопка?
-    bool playName:1;        // воспроизводить имя?
+    bool reserved15:1;      // ex. воспроизводить имя?
     //--------16 штук граница-------------------
-    bool playEffect:1;      // воспроизводить эффект?
-    bool playMP3:1;         // режим mp3-плеера
+    bool reserved16:1;      // ex. воспроизводить эффект?
+    bool reserved17:1;      // ex. режим mp3-плеера
     uint8_t alarmSound:3;   // звук будильника ALARM_SOUND_TYPE
     uint8_t playTime:3;     // воспроизводить время?
     uint8_t GaugeType:2;    // тип индикатора
@@ -135,16 +135,12 @@ _LAMPFLAGS(){
     isEventsHandled = false;
     isMicOn = false;
     effHasMic = false;
+    mp3mute = false;
     dRand = false;
-    isOnMP3 = false;
     isBtn = true;
     showName = false;
     playTime = 0; //TIME_SOUND_TYPE::TS_NONE; // воспроизводить время?
-    playName = false; // воспроизводить имя?
-    playEffect = false; // воспроизводить эффект?
     alarmSound = 0; //ALARM_SOUND_TYPE::AT_NONE;
-    MP3eq = 0;
-    playMP3 = false;
     limitAlarmVolume = false;
     GaugeType = GAUGETYPE::GT_VERT;
 }
@@ -165,7 +161,8 @@ private:
     uint8_t storedBright;               // "запасное" значение яркости
     uint8_t BFade;                      // затенение фона под текстом
 
-    bool mp3mute = false;               // времянка
+    // глушен ли мп3 плеер (времянка)
+    bool mp3mute = false;
 
     // GPIO's
     // это должен быть gpio_num_t в есп32, но пока нужна совместимость с 8266 держим инт
@@ -200,14 +197,6 @@ private:
      */
     uint8_t _get_brightness(bool absolute=false);
 
-    // temp disable
-    void playEffect(bool isPlayName = false, effswitch_t action = effswitch_t::next){};
-
-    /**
-     * @brief effectiveley wipes LedBuffers and fills LED Strip with Black
-     * 
-     */
-    //void _wipe_screen();
 
 public:
     // c-tor
@@ -288,6 +277,10 @@ public:
     bool isAlarm() {return mode == LAMPMODE::MODE_ALARMCLOCK;}
     bool isWarning() {return lampState.isWarning;}
 
+    // return MP3 speaker Mute state
+    bool isMP3mute() const { return mp3mute; }
+    void setMP3mute(bool state){ mp3mute = state; }
+
 #ifdef EMBUI_USE_MQTT
     void setmqtt_int(int val=DEFAULT_MQTTPUB_INTERVAL);
 #endif
@@ -367,16 +360,6 @@ public:
      * 
      */
     void clearDrawBuf() { CRGB c = CRGB::Black; fillDrawBuf(c); }
-
-    bool isONMP3() {return mp3mute;}
-    void setONMP3(bool flag) { mp3mute=flag; }
-
-    void setPlayTime(uint8_t val) {flags.playTime = val;}
-    void setPlayName(bool flag) {flags.playName = flag;}
-    void setPlayEffect(bool flag) {flags.playEffect = flag;}
-    void setPlayMP3(bool flag) {flags.playMP3 = flag;}
-    void setLimitAlarmVolume(bool flag) {flags.limitAlarmVolume = flag;}
-    void setEqType(uint8_t val) {flags.MP3eq = val;}
 
     /**
      * @brief prints current time on screen

--- a/src/main.h
+++ b/src/main.h
@@ -56,7 +56,7 @@ JeeUI2 lib used under MIT License Copyright (c) 2019 Marsel Akhkamov
 #endif
 
 #define LAMPFW_VERSION_MAJOR     3
-#define LAMPFW_VERSION_MINOR     4
+#define LAMPFW_VERSION_MINOR     5
 #define LAMPFW_VERSION_REVISION  0
 
 #define LAMPFW_VERSION_VALUE     (MAJ, MIN, REV) ((MAJ) << 16 | (MIN) << 8 | (REV))


### PR DESCRIPTION
+ implement run-time configuration for address leds RGB color order option for WS2812, Closes #54
+ update windows batch installer
+ add font Awesome icons to UI buttons
+ reworked LOG macros, updated macro will allow to set severity level and component tag
* DFPlayer adapter
   - use forked DFMiniMp3 lib
   - keep cfg in json file
   - add effect track loop function
+ Button - reimplement button control
   - use new ESPAsyncButton library for button handling
   - implement event-based button<>lamp communication
   - implement UI configuration for button, gpio, logic level, etc...
   - implement UI configuration for button events, i.e. mapping actions to button events
   - implement UI configuration for button timings 
* Effects
   - removed rudiment "individual brightness" from effect configs
   - EffectFlags add control to randomly switch flags
   - fix TetrisClock orientation
   - исправлен эффект "Узоры" на широких экранах
   - fix fireworks running on large screens. Closes #47
+ TM1637 rework
   - tm's options are kept in a display.json file
   - modified 1637 driver to handle appended messages
   - TMDisplay class now handles events from a message bus
     - show IP on WiFi connect
     - show power On/Off
     - show Brightness change
     - tm display track brightness control from button events
+ Lamp class refactoring
   - replace EFFSWITCH enum with enum class effswitch_t
   - rename Lamp::effects member to Lamp::effwrkr
   - remove long obsolete sync_parameters()
   - rename overloaded Lamp::switcheffect to private Lamp::_switcheffect
+ add IPC to EmbUI.feeders event publisher
+ Implement ESP32 event loop bus for exchangind control messages between lamp's componets
   - control matrix MOSFET via event bus
   - power on/off events via event loop bus
   - brightness control events
   - effect switch events
- remove obsolete code
   - RTC module related libs and code
   - DS temp sensor related
   - E131 related code
   - remove MP3PLAYER define
   - remove obsolete ESP_USE_BUTTON define and related code
   - убрана кнопка "калибровка микрофона"
   - remove button actions from interfaces.cpp
   - remove old tm methood calls from encoder and rtc
   - alarm
   - events
   - gauge
   - some webui related code
   - code related to pending/current effect switching from EffectWorker
- Other
   - восстанавливать статус активности микрофона после перезагрузки. Closes #19
   - removed build_time define MIC_EFFECTS