### PR TITLE
Schfix

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -42,21 +42,17 @@
 void run_action(ra act){
   LOG(printf, "run_action: %d\n", static_cast<int>(act));
   switch (act){
-    // AUX PIN flip
+/*
+    // AUX PIN flip (obsolete, gpio is in lamp's strutc now )
     case ra::aux_flip : {
       if ( embui.paramVariant(TCONST_aux_gpio) == -1) return;    // if AUX pin is not set, than quit
       run_action(ra::aux, !digitalRead(embui.paramVariant(TCONST_aux_gpio)) );  // we simply flip the state here
       break;
     }
-
+*/
     // demo next effect
     case ra::demo_next : {
-      if (myLamp.getLampFlagsStuct().demoRandom)
-        myLamp.switcheffect(effswitch_t::rnd);
-      else
-        myLamp.switcheffect(effswitch_t::next);
-
-      //run_action(ra::eff_switch, myLamp.effects.getEffnum() );     // call switch effect as in GUI/main page
+      myLamp.demoNext();
       break;
     }
 

--- a/src/effects.h
+++ b/src/effects.h
@@ -1800,7 +1800,7 @@ private:
     uint8_t thisVal;
     uint8_t thisMax;
 
-    Task switcher;                  // flag changer
+    Task *switcher;                  // flag changer
 
     //Germany
     void germany(uint8_t i);
@@ -2187,8 +2187,8 @@ class TetrisClock : public EffectCalc {
     TetrisMatrixDraw t_m;       // The "M" of AM/PM
     TetrisMatrixDraw t_ap;      // The "P" or "A" of AM/PM
 
-    Task seconds;               // seconds pulse
-    Task animatic;              // animation task
+    Task *seconds;               // seconds pulse
+    Task *animatic;              // animation task
 
     bool animation_idle;        // animation in progress
     bool hour24{1};             // 12/24 hour mode
@@ -2206,10 +2206,8 @@ class TetrisClock : public EffectCalc {
     String setDynCtrl(UIControl*_val) override;
 
 	public:
-    TetrisClock(std::shared_ptr< LedFB<CRGB> > framebuffer) : EffectCalc(framebuffer.get()), screen(framebuffer), t_clk(screen), t_m(screen), t_ap(screen) {
-        screen.setRotation(2);
-    }
-    //~TetrisClock();
+    TetrisClock(std::shared_ptr< LedFB<CRGB> > framebuffer);
+    ~TetrisClock();
     void load() override; 
     bool run() override;
 };

--- a/src/effectworker.cpp
+++ b/src/effectworker.cpp
@@ -1091,10 +1091,10 @@ void EffectWorker::start(){
 }
 
 void EffectWorker::stop(){
-  std::unique_lock<std::mutex> lock(_mtx);
   _status = false;                  // task will self destruct on next iteration
-  worker.reset();
-  display.clear();
+  //std::lock_guard<std::mutex> lock(_mtx);
+  //worker.reset();
+  //display.clear();
   display.canvasProtect(false);     // force clear persistent flag for frambuffer (if any) 
 }
 

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -737,11 +737,6 @@ void block_effect_controls(Interface *interf, const JsonObject *data, const char
                     , ctrl->getVal()
                     , ctrlName
                     );
-/*
-#ifdef EMBUI_USE_MQTT
-                    embui.publish(MQT_effect_controls + ctrlId, ctrl->getVal(), true);
-#endif
-*/
                     break;
                 }
             case CONTROL_TYPE::CHECKBOX :
@@ -755,18 +750,10 @@ void block_effect_controls(Interface *interf, const JsonObject *data, const char
                     , ctrlName
                     , true
                     );
-/*
-#ifdef EMBUI_USE_MQTT
-                    embui.publish(MQT_effect_controls + ctrlId, ctrl->getVal(), true);
-#endif
-*/                    break;
+                    break;
                 }
             default:
-/*
-#ifdef EMBUI_USE_MQTT
-                embui.publish(MQT_effect_controls + ctrlId, ctrl->getVal(), true);
-#endif
-*/                break;
+                break;
         }
     }
 
@@ -934,9 +921,7 @@ void ui_page_effects(Interface *interf, const JsonObject *data, const char* acti
  */
 void set_demoflag(Interface *interf, const JsonObject *data, const char* action){
     if (!data) return;
-    // Специально не сохраняем, считаю что демо при старте не должно запускаться
     bool newdemo = (*data)[K_demo];
-
     myLamp.demoMode(newdemo);
     // this might not be working
     myLamp.setDRand(myLamp.getLampFlagsStuct().demoRandom);
@@ -1045,7 +1030,7 @@ void page_settings_other(Interface *interf, const JsonObject *data, const char* 
     interf->number_constrained(V_dev_brtscale, static_cast<int>(myLamp.getBrightnessScale()), "Brightness Scale", 1, 5, static_cast<int>(MAX_BRIGHTNESS));
 
     interf->json_section_line();
-        interf->range(T_DemoTime, embui.paramVariant(T_DemoTime).as<int>(), DEMO_MIN_PERIOD, DEMO_MAX_PERIOD, DEMO_PERIOD_STEP, TINTF_03F);
+        interf->range(T_DemoTime, static_cast<int>(myLamp.getDemoTime()), DEMO_MIN_PERIOD, DEMO_MAX_PERIOD, DEMO_PERIOD_STEP, TINTF_03F);
         float sf = embui.paramVariant(TCONST_spdcf);
         interf->range(TCONST_spdcf, sf, 0.25f, 4.0f, 0.25f, TINTF_0D3, false);
     interf->json_section_end(); // line

--- a/src/lamp.cpp
+++ b/src/lamp.cpp
@@ -431,7 +431,7 @@ void Lamp::demoMode(bool active){
     }
   }
 
-  opts.flag.demoMode == active;
+  opts.flag.demoMode = active;
 
   // save demo state if required
   if (opts.flag.restoreState)

--- a/src/lamp.cpp
+++ b/src/lamp.cpp
@@ -44,6 +44,7 @@ JeeUI2 lib used under MIT License Copyright (c) 2019 Marsel Akhkamov
 #include "evtloop.h"
 #include "nvs_handle.hpp"
 
+#define DEFAULT_EFFECT_NUM  13  // неопалимая купина
 
 Lamp::Lamp() : effwrkr(&lampState){
   lampState.micAnalyseDivider = 1; // анализ каждый раз
@@ -111,7 +112,9 @@ void Lamp::lamp_init(){
   }
 
   // switch to last running effect
-  run_action(ra::eff_switch, embui.paramVariant(V_effect_idx));
+  uint16_t eff_idx = DEFAULT_EFFECT_NUM;
+  handle->get_item(V_effect_idx, eff_idx);
+  run_action(ra::eff_switch, eff_idx);
 
   if (opts.flag.restoreState && opts.flag.pwrState){
     opts.flag.pwrState = false;       // reset it first, so that power() method would know that we are in off state for now
@@ -377,7 +380,9 @@ void Lamp::_switcheffect(effswitch_t action, bool fade, uint16_t effnb) {
 
   // if lamp is not in Demo mode, then need to save new effect in config
   if(!opts.flag.demoMode){
-    embui.var(V_effect_idx, _swState.pendingEffectNum);
+    std::unique_ptr<nvs::NVSHandle> handle = nvs::open_nvs_handle(T_lamp, NVS_READWRITE, NULL);
+    handle->set_item(V_effect_idx, _swState.pendingEffectNum);
+    //embui.var(V_effect_idx, _swState.pendingEffectNum);
   } else {
     myLamp.demoReset();
   }

--- a/src/lamp.h
+++ b/src/lamp.h
@@ -303,7 +303,7 @@ public:
     void demoMode(bool active);
 
     // reset demo timer
-    void demoReset(){ if (demoTask) demoTask->restart(); }
+    void demoReset(){ if (demoTask) demoTask->restartDelayed(); }
 
     /**
      * @brief Set the Demo Timer period
@@ -314,6 +314,13 @@ public:
 
     // get demo period
     uint32_t getDemoTime() const { return demoTime; }
+
+    /**
+     * @brief switch to next effect in demo mode
+     * 
+     */
+    void demoNext();
+
 
     void setEffHasMic(bool flag) {opts.flag.effHasMic = flag;}
     void setDRand(bool flag) {opts.flag.demoRandom = flag; lampState.isRandDemo = flag; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,8 +122,9 @@ void setup() {
 
 void loop() {
     embui.handle(); // цикл, необходимый фреймворку
-
     myLamp.handle(); // цикл, обработка лампы
+    // do not have anything usefull there except mike and ftp
+    vTaskDelay(1);
 }
 
 //------------------------------------------


### PR DESCRIPTION
demo bugs

 - wrong demo time period displayed in webui
 - fix restarting demo timer when manually change effects
 - some old code removed

 - Move effect number save location to NVS

 - fix: Demo switch displayed wrong state in WebUI

 - workaround race conditions in TaskScheduler

TaskScheduler is not safe when adding/deleting task objects asynchronously
When used in effects dunamic tasks could crash on destruct. WA it with SD, a hakish but more reliable.

Fixes #84
