### PR TITLE
experimental support for Arduino core 3 with Huidu boards

### DIFF
--- a/boards/huidu_hd.json
+++ b/boards/huidu_hd.json
@@ -1,11 +1,14 @@
 {
   "build": {
     "arduino": {
-      "ldscript": "esp32s3_out.ld"
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_8MB.csv",
+      "memory_type": "qio_qspi"
     },
     "core": "esp32",
     "extra_flags": [
-      "-DARDUINO_HuiduHDWFX",
+      "-DARDUINO_HUIDU_HD_WFX",
+      "-DBOARD_HAS_PSRAM",
       "-DARDUINO_USB_MODE=1",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"
@@ -20,7 +23,7 @@
       ]
     ],
     "mcu": "esp32s3",
-    "variant": "esp32s3"
+    "variant": "wifiduino32s3"
   },
   "connectivity": [
     "bluetooth",

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,6 @@ extra_configs =
 ; build flags for esp32
 [flags]
 build_src_flags =
-;    -std=gnu++14
 build_unflags =
     -std=gnu++11
 build_flags =
@@ -105,8 +104,6 @@ board_build.partitions = extra/esp32_4MiB.csv
 ; more info here https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA/issues/433
 [env:hdwf2]
 extends = esp32_base
-; Tasmota's core, based on v2.0.18 with NTP fix
-platform = https://github.com/Jason2866/platform-espressif32/releases/download/2024.06.00/platform-espressif32.zip
 board = huidu_hd
 board_build.partitions = extra/default_8MB.csv
 build_flags =


### PR DESCRIPTION
Huidu's SPI flash has a strange issue with Core 3.x, it prevents mounting LittleFS in rw mode.
Probably '-D BOARD_HAS_PSRAM' build flag is a feasible workaround for it, although board does not have SPI-RAM.