### PR TITLE
Fix: potential bootloop on wrong intitialization order

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -52,12 +52,10 @@ vortigont =
 
 [env]
 framework = arduino
+; Tasmota's Platform 2025.04.30 Tasmota Arduino Core 3.1.3.250411 based on IDF 5.3.2.250403 (this build crashes on boot)
+;platform = https://github.com/tasmota/platform-espressif32/releases/download/2025.04.30/platform-espressif32.zip
 ; Tasmota's Platform 2025.03.30 Tasmota Arduino Core 3.1.3.250302 based on IDF 5.3.2.250228
 platform = https://github.com/tasmota/platform-espressif32/releases/download/2025.03.30/platform-espressif32.zip
-; Tasmota's Platform 2025.02.30 Tasmota Arduino Core 3.1.1.250203 based on IDF 5.3.2.250120
-;platform = https://github.com/tasmota/platform-espressif32/releases/download/2025.02.30/platform-espressif32.zip
-; Tasmota's platform, based on Arduino Core v3.0.4
-;platform = https://github.com/tasmota/platform-espressif32/releases/download/2024.08.11/platform-espressif32.zip
 ;platform_packages = 
 ;  platformio/framework-arduinoespressif32 @https://github.com/tasmota/arduino-esp32/releases/download/3.0.4.240826/framework-arduinoespressif32.zip
 ;  platformio/framework-arduinoespressif32-libs

--- a/platformio.ini
+++ b/platformio.ini
@@ -52,10 +52,10 @@ vortigont =
 
 [env]
 framework = arduino
-; Tasmota's Platform 2025.04.30 Tasmota Arduino Core 3.1.3.250411 based on IDF 5.3.2.250403 (this build crashes on boot)
-;platform = https://github.com/tasmota/platform-espressif32/releases/download/2025.04.30/platform-espressif32.zip
+; Tasmota's Platform 2025.05.40 Tasmota Arduino Core 3.2.0.250504 based on IDF 5.4.0.250501
+platform = https://github.com/tasmota/platform-espressif32/releases/download/2025.05.40/platform-espressif32.zip
 ; Tasmota's Platform 2025.03.30 Tasmota Arduino Core 3.1.3.250302 based on IDF 5.3.2.250228
-platform = https://github.com/tasmota/platform-espressif32/releases/download/2025.03.30/platform-espressif32.zip
+;platform = https://github.com/tasmota/platform-espressif32/releases/download/2025.03.30/platform-espressif32.zip
 ;platform_packages = 
 ;  platformio/framework-arduinoespressif32 @https://github.com/tasmota/arduino-esp32/releases/download/3.0.4.240826/framework-arduinoespressif32.zip
 ;  platformio/framework-arduinoespressif32-libs

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,7 +41,7 @@ common =
 
 vortigont =
     ;https://github.com/vortigont/EmbUI
-    vortigont/EmbUI @ ~4.2.1
+    vortigont/EmbUI @ ~4.2.2
     https://github.com/vortigont/LedFB
     https://github.com/vortigont/TM1637
     vortigont/ESPAsyncButton @ ~1.2
@@ -54,8 +54,6 @@ vortigont =
 framework = arduino
 ; Tasmota's Platform 2025.05.40 Tasmota Arduino Core 3.2.0.250504 based on IDF 5.4.0.250501
 platform = https://github.com/tasmota/platform-espressif32/releases/download/2025.05.40/platform-espressif32.zip
-; Tasmota's Platform 2025.03.30 Tasmota Arduino Core 3.1.3.250302 based on IDF 5.3.2.250228
-;platform = https://github.com/tasmota/platform-espressif32/releases/download/2025.03.30/platform-espressif32.zip
 ;platform_packages = 
 ;  platformio/framework-arduinoespressif32 @https://github.com/tasmota/arduino-esp32/releases/download/3.0.4.240826/framework-arduinoespressif32.zip
 ;  platformio/framework-arduinoespressif32-libs

--- a/src/effectworker.cpp
+++ b/src/effectworker.cpp
@@ -438,17 +438,6 @@ void EffConfiguration::embui_preset_delete(Interface *interf){
 ///////////////////////////////////////////
 //  ***** EffectWorker implementation *****
 
-EffectWorker::EffectWorker() {
-  // сформировать и опубликовать блок контролов текущего эффекта
-  embui.action.add(A_effect_ctrls, [&](Interface *interf, JsonObjectConst data, const char* action){ _effCfg.embui_control_vals(interf); });
-  // preset switcher
-  embui.action.add(A_eff_preset, [&](Interface *interf, JsonObjectConst data, const char* action){ switchEffectPreset(data[A_eff_preset]); _effCfg.embui_control_vals(interf); });
-  embui.action.add(A_eff_preset_lbl, [&](Interface *interf, JsonObjectConst data, const char* action){ _effCfg.embui_preset_rename(interf, data, action); });
-  embui.action.add(A_eff_preset_new, [&](Interface *interf, JsonObjectConst data, const char* action){ _effCfg.embui_preset_clone(interf); });
-  embui.action.add(A_eff_preset_remove, [&](Interface *interf, JsonObjectConst data, const char* action){ _effCfg.embui_preset_delete(interf); });
-
-}
-
 EffectWorker::~EffectWorker(){
   if(_runnerTask_h) vTaskDelete(_runnerTask_h);
   _runnerTask_h = nullptr;
@@ -458,6 +447,17 @@ EffectWorker::~EffectWorker(){
   embui.action.remove(A_eff_preset_remove);
   embui.action.remove(A_eff_preset);
 };
+
+void EffectWorker::embui_register(){
+  // сформировать и опубликовать блок контролов текущего эффекта
+  embui.action.add(A_effect_ctrls, [&](Interface *interf, JsonObjectConst data, const char* action){ _effCfg.embui_control_vals(interf); });
+  // preset switcher
+  embui.action.add(A_eff_preset, [&](Interface *interf, JsonObjectConst data, const char* action){ switchEffectPreset(data[A_eff_preset]); _effCfg.embui_control_vals(interf); });
+  embui.action.add(A_eff_preset_lbl, [&](Interface *interf, JsonObjectConst data, const char* action){ _effCfg.embui_preset_rename(interf, data, action); });
+  embui.action.add(A_eff_preset_new, [&](Interface *interf, JsonObjectConst data, const char* action){ _effCfg.embui_preset_clone(interf); });
+  embui.action.add(A_eff_preset_remove, [&](Interface *interf, JsonObjectConst data, const char* action){ _effCfg.embui_preset_delete(interf); });
+}
+
 
 EffectWorker::effect_iterator_t EffectWorker::_getCurEffIterator(){
   auto idx = _effItem.eid;

--- a/src/effectworker.h
+++ b/src/effectworker.h
@@ -414,12 +414,18 @@ private:
 
 public:
     // дефолтный конструктор
-    EffectWorker();
+    EffectWorker(){};
     ~EffectWorker();
 
     // noncopyable
     EffectWorker (const EffectWorker&) = delete;
     EffectWorker& operator= (const EffectWorker&) = delete;
+
+    /**
+     * @brief register EmbUI handlers
+     * 
+     */
+    void embui_register();
 
     /**
      * @brief loads effect index

--- a/src/lamp.cpp
+++ b/src/lamp.cpp
@@ -55,11 +55,6 @@ Copyright © 2020 Dmytro Korniienko (kDn)
 Lamp::Lamp() {
   // initialize fader instance
   LEDFader::getInstance()->setLamp(this);
-
-  // demo on/off
-  embui.action.add(T_demoOn, [this](Interface *interf, JsonObjectConst data, const char* action){ _embui_demoOn(interf, data, action); } );
-  embui.action.add(T_demoRndCtrls, [this](Interface *interf, JsonObjectConst data, const char* action){ _embui_demoRndCtrls(interf, data, action); } );
-  embui.action.add(T_demoRndOrder, [this](Interface *interf, JsonObjectConst data, const char* action){ _embui_demoRndOrder(interf, data, action); } );
 }
 
 Lamp::~Lamp(){
@@ -143,6 +138,13 @@ void Lamp::lamp_init(){
   if (opts.flag.pwrState){
     power(true);
   }
+
+  // register embui handlers
+  // demo on/off
+  embui.action.add(T_demoOn, [this](Interface *interf, JsonObjectConst data, const char* action){ _embui_demoOn(interf, data, action); } );
+  embui.action.add(T_demoRndCtrls, [this](Interface *interf, JsonObjectConst data, const char* action){ _embui_demoRndCtrls(interf, data, action); } );
+  embui.action.add(T_demoRndOrder, [this](Interface *interf, JsonObjectConst data, const char* action){ _embui_demoRndOrder(interf, data, action); } );  
+  effwrkr.embui_register();
 
   vopts.flag.initialized = true;
 }


### PR DESCRIPTION
компилятор может неверно выстроить порядок инстанциации предопределённых объектов предопределенные инстансы классов Lamp и EffectWorker, могут попытаться зарегистрировать акшены в инстансе EmbUI еще до его создания,  что приводит к падению и bootloop.
решение: выносим регистрацию акшенов из конструктора в отдельный вызов осуществляемый при загрузке конфигурации класса лампы

upd: обновлённые версии ядра Tasmota и библиотеки EmbUI