### PR TITLE
OmniCron - отслеживание статуса панели

### DIFF
--- a/resources/html/js/firelamp.js
+++ b/resources/html/js/firelamp.js
@@ -61,7 +61,7 @@ function omnicron_tasks_load(arg){
   // rename keys for each array's elements in 'event' obj
   tasks_data.event.forEach((obj, idx, array) => {
     ui_obj.section = "omni_task" + idx
-    ui_obj.block[0]["value"] = obj.active
+    ui_obj.block[0]["value"] = obj.active ? true : false
     ui_obj.block[1]["value"] = obj.descr
     ui_obj.block[2]["value"] = idx        // edit btn
     ui_obj.block[3]["value"] = idx        // del btn

--- a/resources/html/js/ui.json
+++ b/resources/html/js/ui.json
@@ -2022,10 +2022,14 @@
           },
           {
             "id": "active",
-            "html":"input",
-            "label":"Активна",
-            "type":"checkbox",
-            "class":"pure-u-1-5 pure-u-lg-1-12"
+            "html":"select",
+            "label":"Активность",
+            "section":"options",
+            "block":[
+              { "value":0, "label":"Отключена" },
+              { "value":1, "label":"Активна всегда" },
+              { "value":2, "label":"Отслеживать вкл./выкл. панели" }
+            ]
           },
           {
             "id": "descr",

--- a/src/modules/omnicron/omnicron.hpp
+++ b/src/modules/omnicron/omnicron.hpp
@@ -42,10 +42,15 @@
 
 class OmniCron : public GenericModule {
 
-//using omni_task_t = std::tuple<cronos_tid, int32_t, int32_t>;
-
 	struct omni_task_t {
-		bool active;
+		// task active state
+		enum class active_t {
+			disabled,		// task is not active
+			enabled,		// task is active
+			pwron			// task is axtive when device is on
+		};
+
+		active_t active;
 		cronos_tid tid;
 		std::string descr;
 		std::string crontab;
@@ -69,6 +74,7 @@ class OmniCron : public GenericModule {
 
 public:
 	OmniCron();
+	~OmniCron();
 
   void start() override;
   void stop() override;
@@ -80,6 +86,14 @@ public:
 	void generate_cfg(JsonVariant cfg) const override final;
 
 private:
+
+	// track device's power state
+	bool _device_pwr{false};
+
+	esp_event_handler_instance_t _hdlr_lmp_change_evt = nullptr;
+
+	// change events handler
+    void _lmpChEventHandler(esp_event_base_t base, int32_t id, void* data);
 
 	void _cron_callback(cronos_tid id, void* arg);
 


### PR DESCRIPTION
активность задачи может быть синхронизирована со статусом включения панели - задача выполняется только когда панель включена. Может быть полезно для задач переключающих эффекты, профили и пр. дабы предотвратить бесполезные изменения и сохранение параметров во флеш.